### PR TITLE
change travis-ci link to point to fcrepo4 rather than fcrepo4-labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 WebAC Authorization Delegate Module for the Fedora 4 Repository. This is an implementation of the W3C's proposed WebAccessControl at: [https://www.w3.org/wiki/WebAccessControl](https://www.w3.org/wiki/WebAccessControl).
 
-[![Build Status](https://travis-ci.org/fcrepo4-labs/fcrepo-module-auth-webac.png?branch=master)](https://travis-ci.org/fcrepo4-labs/fcrepo-module-auth-webac)
+[![Build Status](https://travis-ci.org/fcrepo4/fcrepo-module-auth-webac.png?branch=master)](https://travis-ci.org/fcrepo4/fcrepo-module-auth-webac)
 
 This module enables an ACL based access control to the Fedora repository. Each protected resource should have an ACL file associated with it either directly or via an ancestor. The ACL file defines authorization based on three entities: 1) who has access, 2) what are the access permissions, and 3) to which resource. The ontology of the ACL RDF file can be found at: [http://www.w3.org/ns/auth/acl](http://www.w3.org/ns/auth/acl).
 


### PR DESCRIPTION
The travis status link points at fcrepo4-labs; it should point at fcrepo4.