### PR TITLE
Use getEffectiveAcl in LinkHeaderProvider to get Acl recursively.

### DIFF
--- a/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
@@ -15,7 +15,6 @@
  */
 package org.fcrepo.auth.webac;
 
-import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.slf4j.LoggerFactory.getLogger;
 import static com.hp.hpl.jena.rdf.model.ResourceFactory.createProperty;
@@ -38,7 +37,6 @@ import org.slf4j.Logger;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multimap;
-import com.hp.hpl.jena.rdf.model.Model;
 import com.hp.hpl.jena.rdf.model.Resource;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,14 +65,13 @@ public class LinkHeaderProvider implements UriAwareHttpHeaderFactory {
         final Session internalSession = sessionFactory.getInternalSession();
         final IdentifierConverter<Resource, FedoraResource> translator =
                 new DefaultIdentifierTranslator(internalSession);
-        final Model model = createDefaultModel();
         final ListMultimap<String, String> headers = ArrayListMultimap.create();
 
         LOGGER.debug("Adding WebAC Link Header for Resource: {}", resource);
         // Get the correct Acl for this resource
         WebACRolesProvider.getEffectiveAcl(resource).ifPresent(acls -> {
             // If the Acl is present we need to use the internal session to get its URI
-            nodeService.find(internalSession, acls.getRight().getPath())
+            nodeService.find(internalSession, acls.resource.getPath())
             .getTriples(translator, PropertiesRdfContext.class)
             .asModel().listObjectsOfProperty(createProperty(WEBAC_ACCESS_CONTROL_VALUE))
             .forEachRemaining(linkObj -> {

--- a/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
@@ -18,10 +18,9 @@ package org.fcrepo.auth.webac;
 import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.slf4j.LoggerFactory.getLogger;
+import static com.hp.hpl.jena.rdf.model.ResourceFactory.createProperty;
 
 import java.net.URI;
-import java.util.Optional;
-
 import javax.jcr.Session;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriInfo;
@@ -34,7 +33,6 @@ import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.modeshape.rdf.impl.DefaultIdentifierTranslator;
 import org.fcrepo.kernel.modeshape.rdf.impl.PropertiesRdfContext;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -74,19 +72,20 @@ public class LinkHeaderProvider implements UriAwareHttpHeaderFactory {
 
         LOGGER.debug("Adding WebAC Link Header for Resource: {}", resource);
         // Get the correct Acl for this resource
-        final Optional<Pair<URI, FedoraResource>> acls = WebACRolesProvider.getEffectiveAcl(resource);
-        if (acls.isPresent()) {
-            // If the Acl is present we probably need to use the internal session to get it's URI
-            nodeService.find(internalSession, acls.get().getRight().getPath())
-                    .getTriples(translator, PropertiesRdfContext.class)
-                    .filter(t -> model.asStatement(t).getPredicate().hasURI(WEBAC_ACCESS_CONTROL_VALUE))
-                    .filter(t -> t.getObject().isURI())
-                    .forEachRemaining(t -> {
-                headers.put("Link", Link.fromUri(uriInfo.getBaseUriBuilder()
-                        .path(translator.convert(model.asStatement(t).getObject().asResource()).getPath())
-                        .toString()).rel("acl").build().toString());
-                    });
-        }
+        WebACRolesProvider.getEffectiveAcl(resource).ifPresent(acls -> {
+            // If the Acl is present we need to use the internal session to get its URI
+            nodeService.find(internalSession, acls.getRight().getPath())
+            .getTriples(translator, PropertiesRdfContext.class)
+            .asModel().listObjectsOfProperty(createProperty(WEBAC_ACCESS_CONTROL_VALUE))
+            .forEachRemaining(linkObj -> {
+                if (linkObj.isURIResource()) {
+                    final Resource acl = linkObj.asResource();
+                    final String aclPath = translator.convert(acl).getPath();
+                    final URI aclUri = uriInfo.getBaseUriBuilder().path(aclPath).build();
+                    headers.put("Link", Link.fromUri(aclUri).rel("acl").build().toString());
+                }
+            });
+        });
 
         return headers;
     }

--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -62,6 +62,7 @@ import javax.jcr.Session;
 
 import org.fcrepo.auth.roles.common.AccessRolesProvider;
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.exception.MalformedRdfException;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.models.NonRdfSourceDescription;
@@ -395,8 +396,13 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
             resource.getTriples(translator, PropertiesRdfContext.class)
                 .filter(t -> model.asStatement(t).getPredicate().hasURI(WEBAC_ACCESS_CONTROL_VALUE))
-                .filter(t -> t.getObject().isURI())
                 .forEachRemaining(t -> {
+                    if (!t.getObject().isURI()) {
+                        final String error = String.format("The value %s of the %s on this resource must be a URI",
+                                t.getObject(), WEBAC_ACCESS_CONTROL_VALUE);
+                        LOGGER.error(error);
+                        throw new MalformedRdfException(error);
+                    }
                     acls.add(t.getObject().getURI());
                 });
 

--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -386,7 +386,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
      * any permissions that correspond to access to that parent. This ACL resource may or may not exist,
      * and it may be external to the fedora repository.
      */
-    private static Optional<ACLHandle> getEffectiveAcl(final FedoraResource resource) {
+    static Optional<ACLHandle> getEffectiveAcl(final FedoraResource resource) {
         try {
             final IdentifierConverter<Resource, FedoraResource> translator =
                 new DefaultIdentifierTranslator(resource.getNode().getSession());

--- a/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -179,6 +179,17 @@ public class WebACRecipesIT extends AbstractResourceIT {
             assertTrue("Missing Link header", header.isPresent());
         }
 
+        logger.debug("Can username 'smith123' read a child of {}", testObj);
+        final String childObj = ingestObj("/rest/webacl_box1/child");
+        final HttpGet getReq = getObjMethod(childObj.replace(serverAddress, ""));
+        setAuth(getReq, "smith123");
+        try (final CloseableHttpResponse response = execute(getReq)) {
+            assertEquals(HttpStatus.SC_OK, getStatus(response));
+            final Optional<String> header = Arrays.asList(response.getHeaders("Link")).stream().map(Header::getValue)
+                    .filter(aclLink::equals).findFirst();
+            assertTrue("Missing Link header to ACL on parent", header.isPresent());
+
+        }
     }
 
     @Test


### PR DESCRIPTION
Resolves [FCREPO-1881](https://jira.duraspace.org/browse/FCREPO-1881)
Add test to check that Link Header appears on children of an Acl linked resource.
Open getEffectiveAcl to package visibility.