### PR TITLE
Tighten webac module code

### DIFF
--- a/src/main/java/org/fcrepo/auth/webac/ACLHandle.java
+++ b/src/main/java/org/fcrepo/auth/webac/ACLHandle.java
@@ -34,8 +34,8 @@ public class ACLHandle {
     /**
      * Default constructor.
      *
-     * @param uri
-     * @param resource
+     * @param uri the URI pointing to an ACL
+     * @param resource the requested FedoraResource
      */
     public ACLHandle(final URI uri, final FedoraResource resource) {
         this.uri = uri;

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-DEBUG}">
+    <logger name="org.fcrepo.auth" additivity="false" level="${fcrepo.log.auth:-INFO}">
         <appender-ref ref="STDOUT"/>
     </logger>
     <logger name="org.fcrepo" additivity="false" level="${fcrepo.log:-INFO}">


### PR DESCRIPTION
Resolves: https://jira.duraspace.org/browse/FCREPO-1946

  * Remove unnecessary translations between Triples and Statements
  * Use `static import` when possible
  * Shorten stream-based code by using matching predicates (`anyMatch`, `allMatch`)
  * Use stream collectors where possible
  * Combine predicates where possible
  * Make lambdas more readable by replacing x with more meaningful variable names
  * Change test logging output from DEBUG to INFO
  * Remove unnecessary `uncheck` formulations
  * Update documentation where appropriate
  * Remove the JCR_CONTENT translation, as the Modeshape impl no longer leaks that information
