### PR TITLE
change WebACRolesProvider::getRoles to return a Collection

### DIFF
--- a/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/WebACRolesProvider.java
@@ -25,7 +25,6 @@ import static java.util.stream.Stream.empty;
 import static java.util.stream.Stream.of;
 import static com.hp.hpl.jena.graph.NodeFactory.createURI;
 import static com.hp.hpl.jena.rdf.model.ModelFactory.createDefaultModel;
-import static com.google.common.collect.Maps.transformValues;
 import static org.apache.jena.riot.Lang.TTL;
 import static org.fcrepo.auth.webac.URIConstants.FOAF_AGENT_VALUE;
 import static org.fcrepo.auth.webac.URIConstants.FOAF_GROUP;
@@ -119,7 +118,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
     }
 
     @Override
-    public Map<String, List<String>> findRolesForPath(final Path absPath, final Session session)
+    public Map<String, Collection<String>> findRolesForPath(final Path absPath, final Session session)
             throws RepositoryException {
         return getAgentRoles(locateResource(absPath, session));
     }
@@ -168,14 +167,14 @@ public class WebACRolesProvider implements AccessRolesProvider {
     }
 
     @Override
-    public Map<String, List<String>> getRoles(final Node node, final boolean effective) {
+    public Map<String, Collection<String>> getRoles(final Node node, final boolean effective) {
         return getAgentRoles(nodeService.cast(node));
     }
 
     /**
      *  For a given FedoraResource, get a mapping of acl:agent values to acl:mode values.
      */
-    private Map<String, List<String>> getAgentRoles(final FedoraResource resource) {
+    private Map<String, Collection<String>> getAgentRoles(final FedoraResource resource) {
         LOGGER.debug("Getting agent roles for: {}", resource.getPath());
 
         // Get the effective ACL by searching the target node and any ancestors.
@@ -228,7 +227,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
         // the target (or acl-bearing ancestor) resource path or rdf:type.
         // Then, assign all acceptable acl:mode values to the relevant acl:agent values: this creates a UNION
         // of acl:modes for each particular acl:agent.
-        final Map<String, Set<String>> effectiveRoles = new HashMap<>();
+        final Map<String, Collection<String>> effectiveRoles = new HashMap<>();
         authorizations.stream()
             .filter(checkAccessTo.or(checkAccessToClass))
             .forEach(auth -> {
@@ -241,8 +240,7 @@ public class WebACRolesProvider implements AccessRolesProvider {
 
         LOGGER.debug("Unfiltered ACL: {}", effectiveRoles);
 
-        // Transform the effectiveRoles values from a Set to a List.
-        return transformValues(effectiveRoles, ArrayList::new);
+        return effectiveRoles;
     }
 
     /**

--- a/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -38,6 +38,7 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -140,7 +141,7 @@ public class WebACRolesProviderTest {
                 .thenReturn(new DefaultRdfStream(createURI("subject")));
         when(mockParentNode.getDepth()).thenReturn(0);
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertTrue("There should be no agents in the roles map", roles.isEmpty());
     }
@@ -176,7 +177,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent in the role map", 1, roles.size());
         assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
@@ -205,7 +206,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent in the role map", 1, roles.size());
         assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
@@ -233,7 +234,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertTrue("There should be no agents associated with this object", roles.isEmpty());
     }
@@ -259,7 +260,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent in the role map", 1, roles.size());
         assertEquals("The agent should have exactly two modes", 2, roles.get(agent).size());
@@ -294,7 +295,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent in the roles map", 1, roles.size());
         assertEquals("The agent should have exactly one mode", 1, roles.get(agent).size());
@@ -328,7 +329,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
         assertEquals("The agent should have one mode", 1, roles.get(agent).size());
@@ -363,7 +364,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly two agents", 2, roles.size());
         assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
@@ -401,7 +402,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly two agents", 2, roles.size());
         assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
@@ -438,7 +439,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1, mockAuthorizationResource2));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly agent", 1, roles.size());
         assertEquals("The agent should have one mode", 1, roles.get(agent1).size());
@@ -482,7 +483,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly two agents", 2, roles.size());
         assertEquals("The agent should have two modes", 2, roles.get(agent1).size());
@@ -527,7 +528,7 @@ public class WebACRolesProviderTest {
 
         when(mockAclResource.getChildren()).thenReturn(of(mockAuthorizationResource1));
 
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly zero agents", 0, roles.size());
     }
@@ -541,7 +542,7 @@ public class WebACRolesProviderTest {
         when(mockResource.getPath()).thenReturn("/");
         when(mockResource.getTypes()).thenReturn(
                 Arrays.asList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
         assertEquals("The agent should have zero modes", 0, roles.get(agent1).size());
@@ -560,7 +561,7 @@ public class WebACRolesProviderTest {
                 Arrays.asList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
 
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/logback-test.xml");
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
         System.clearProperty(ROOT_AUTHORIZATION_PROPERTY);
 
         assertEquals("There should be exactly one agent", 1, roles.size());
@@ -578,7 +579,7 @@ public class WebACRolesProviderTest {
                 Arrays.asList(URI.create(REPOSITORY_NAMESPACE + "Resource")));
 
         System.setProperty(ROOT_AUTHORIZATION_PROPERTY, "./target/test-classes/test-root-authorization.ttl");
-        final Map<String, List<String>> roles = roleProvider.getRoles(mockNode, true);
+        final Map<String, Collection<String>> roles = roleProvider.getRoles(mockNode, true);
         System.clearProperty(ROOT_AUTHORIZATION_PROPERTY);
 
         assertEquals("There should be exactly one agent", 1, roles.size());


### PR DESCRIPTION
Related to: https://jira.duraspace.org/browse/FCREPO-1955

This removes the unnecessary transformation of `Map<String, Set<String>>` to `Map<String, List<String>>`

Depends on https://github.com/fcrepo4/fcrepo-module-auth-rbacl/pull/28