### PR TITLE
Integration test for removing fcr:accessroles

### DIFF
--- a/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
+++ b/src/test/java/org/fcrepo/integration/auth/webac/WebACRecipesIT.java
@@ -759,5 +759,15 @@ public class WebACRecipesIT extends AbstractResourceIT {
         assertEquals(HttpStatus.SC_FORBIDDEN, getStatus(patchReq));
     }
 
+    @Test
+    public void testNoAccessRolesResource() throws IOException {
+        final String objectPath = "/rest/test_accessroles";
+        ingestObj(objectPath);
+        final String accessRolesResource = objectPath + "/fcr:accessroles";
+        final HttpGet getReq = getObjMethod(accessRolesResource);
+        setAuth(getReq, "fedoraAdmin");
+        assertEquals(HttpStatus.SC_NOT_FOUND, getStatus(getReq));
+    }
+
 
 }


### PR DESCRIPTION
- Requests for fcr:accessroles should return 404 when using the WebAC authorization provider
- Depends on https://github.com/fcrepo4/fcrepo-module-auth-rbacl/pull/33

Resolves: https://jira.duraspace.org/browse/FCREPO-1853