### PR TITLE
Follow-on to the removal of jcr.Session from the kernel-api

### DIFF
--- a/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
+++ b/src/main/java/org/fcrepo/auth/webac/LinkHeaderProvider.java
@@ -20,18 +20,19 @@ package org.fcrepo.auth.webac;
 import static org.fcrepo.auth.webac.URIConstants.WEBAC_ACCESS_CONTROL_VALUE;
 import static org.fcrepo.kernel.api.RdfCollectors.toModel;
 import static org.fcrepo.kernel.api.RequiredRdfContext.PROPERTIES;
+import static org.fcrepo.kernel.modeshape.FedoraSessionImpl.getJcrSession;
 import static org.slf4j.LoggerFactory.getLogger;
 import static org.apache.jena.rdf.model.ResourceFactory.createProperty;
 
 import java.net.URI;
 
 import javax.inject.Inject;
-import javax.jcr.Session;
 import javax.ws.rs.core.Link;
 import javax.ws.rs.core.UriInfo;
 
 import org.fcrepo.http.commons.api.UriAwareHttpHeaderFactory;
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.identifiers.IdentifierConverter;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.services.NodeService;
@@ -66,9 +67,9 @@ public class LinkHeaderProvider implements UriAwareHttpHeaderFactory {
     @Override
     public Multimap<String, String> createHttpHeadersForResource(final UriInfo uriInfo, final FedoraResource resource) {
 
-        final Session internalSession = sessionFactory.getInternalSession();
+        final FedoraSession internalSession = sessionFactory.getInternalSession();
         final IdentifierConverter<Resource, FedoraResource> translator =
-                new DefaultIdentifierTranslator(internalSession);
+                new DefaultIdentifierTranslator(getJcrSession(internalSession));
         final ListMultimap<String, String> headers = ArrayListMultimap.create();
 
         LOGGER.debug("Adding WebAC Link Header for Resource: {}", resource.getPath());

--- a/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
+++ b/src/test/java/org/fcrepo/auth/webac/WebACRolesProviderTest.java
@@ -56,11 +56,13 @@ import org.apache.jena.riot.Lang;
 import org.apache.jena.riot.RDFDataMgr;
 import org.fcrepo.auth.roles.common.AccessRolesProvider;
 import org.fcrepo.http.commons.session.SessionFactory;
+import org.fcrepo.kernel.api.FedoraSession;
 import org.fcrepo.kernel.api.RdfStream;
 import org.fcrepo.kernel.api.models.FedoraResource;
 import org.fcrepo.kernel.api.rdf.DefaultRdfStream;
 import org.fcrepo.kernel.api.services.NodeService;
 import org.fcrepo.kernel.modeshape.FedoraResourceImpl;
+import org.fcrepo.kernel.modeshape.FedoraSessionImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -83,10 +85,13 @@ public class WebACRolesProviderTest {
     private Node mockNode, mockParentNode;
 
     @Mock
-    private Session mockSession;
+    private FedoraSessionImpl mockSession;
 
     @Mock
     private SessionFactory mockSessionFactory;
+
+    @Mock
+    private Session mockJcrSession;
 
     @Mock
     private NodeService mockNodeService;
@@ -108,9 +113,10 @@ public class WebACRolesProviderTest {
         setField(roleProvider, "nodeService", mockNodeService);
         setField(roleProvider, "sessionFactory", mockSessionFactory);
 
-        when(mockNodeService.find(eq(mockSession), any())).thenReturn(mockResource);
-        when(mockNode.getSession()).thenReturn(mockSession);
+        when(mockNodeService.find(any(FedoraSession.class), any())).thenReturn(mockResource);
+        when(mockNode.getSession()).thenReturn(mockJcrSession);
         when(mockSessionFactory.getInternalSession()).thenReturn(mockSession);
+        when(mockSession.getJcrSession()).thenReturn(mockJcrSession);
 
         when(mockResource.getNode()).thenReturn(mockNode);
         when(mockNode.getDepth()).thenReturn(0);


### PR DESCRIPTION
Addresses: https://jira.duraspace.org/browse/FCREPO-1868

Depends on https://github.com/fcrepo4/fcrepo4/pull/1123